### PR TITLE
Fix build_interface_map()

### DIFF
--- a/libredex/ClassHierarchy.cpp
+++ b/libredex/ClassHierarchy.cpp
@@ -123,7 +123,7 @@ InterfaceMap build_interface_map(const ClassHierarchy& hierarchy) {
   for (const auto& cls_it : hierarchy) {
     const auto cls = type_class(cls_it.first);
     if (cls == nullptr) continue;
-    if (is_interface(cls)) continue;
+    if (!is_interface(cls)) continue;
     TypeSet implementors;
     get_all_children(hierarchy, cls->get_type(), implementors);
     implementors.insert(cls->get_type());


### PR DESCRIPTION
build_interface_map should ignore non-interface classes, not interface classes. This is a simple logic error.